### PR TITLE
Make The Plugin Global

### DIFF
--- a/resources/views/components/turnstile.blade.php
+++ b/resources/views/components/turnstile.blade.php
@@ -38,7 +38,5 @@
         </div>
     </div>
 
-    @push('scripts')
-        <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onloadTurnstileCallback" defer></script>
-    @endpush
+    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onloadTurnstileCallback" defer></script>
 </x-dynamic-component>


### PR DESCRIPTION
Make the plugin global, so anyone can call it outside filament panel resources (e.g: in Livewire Forms).

AKA: any place you used the filament `forms` into