### PR TITLE
Fix multiple instances

### DIFF
--- a/resources/views/components/turnstile.blade.php
+++ b/resources/views/components/turnstile.blade.php
@@ -9,44 +9,57 @@
 
 <x-dynamic-component :component="$fieldWrapperView" :field="$turnstile">
 
-    <div x-data="{
-            state: $wire.entangle('{{ $statePath }}').defer
+    <div wire:ignore
+         x-data="{
+            state: $wire.entangle('{{ $statePath }}').defer,
+            widgetId: null
         }"
-         wire:ignore
-         x-load-js="['https://challenges.cloudflare.com/turnstile/v0/api.js?onload=onloadTurnstileCallback']"
+         x-load-js="['https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit&onload=onTurnstileLoad']"
          x-init="(() => {
-            let options= {
+            let options = {
+                sitekey: '{{config('turnstile.turnstile_site_key')}}',
+                theme: '{{ $theme }}',
+                size: '{{ $size }}',
+                language: '{{ $language }}',
                 callback: function (token) {
                     $wire.set('{{ $statePath }}', token)
                 },
-
-                errorCallback: function () {
+                'error-callback': function () {
                     $wire.set('{{ $statePath }}', null)
-                },
+                }
             }
 
-            window.onloadTurnstileCallback = () => {
-                turnstile.render($refs.turnstile, options)
+            // Render widget when Turnstile API is ready
+            const renderWidget = () => {
+                if (!window.turnstile || !$refs.turnstile || widgetId !== null) {
+                    return;
+                }
+
+                widgetId = turnstile.render($refs.turnstile, options);
             }
 
-            resetCaptcha = () => {
-                turnstile.reset($refs.turnstile)
+            // Called when Turnstile API loads
+            window.onTurnstileLoad = () => {
+                renderWidget();
             }
 
-            $wire.on('reset-captcha', () => resetCaptcha())
+            // If API already loaded (on re-render), render immediately
+            if (window.turnstile) {
+                renderWidget();
+            }
 
-            const observer = new IntersectionObserver((entries) => {
-                  entries.forEach(entry => {
-                      if (entry.isIntersecting && 
-                          window.turnstile && 
-                          !$refs.turnstile.querySelector('.cf-turnstile')) {
-                          turnstile.render($refs.turnstile, options);
-                      }
-                  });
-              }, { threshold: 0.1 })
+            $wire.on('reset-captcha', () => {
+                if (widgetId !== null && window.turnstile) {
+                    turnstile.reset(widgetId);
+                }
+            })
 
-            if ($refs.turnstile) {
-                observer.observe($refs.turnstile);
+            // Cleanup when component is destroyed
+            return () => {
+                if (widgetId !== null && window.turnstile) {
+                    turnstile.remove(widgetId);
+                    widgetId = null;
+                }
             }
         })()"
     >

--- a/resources/views/components/turnstile.blade.php
+++ b/resources/views/components/turnstile.blade.php
@@ -10,11 +10,11 @@
 <x-dynamic-component :component="$fieldWrapperView" :field="$turnstile">
 
     <div wire:ignore
+         x-load-js="['https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit&onload=onTurnstileLoad']"
          x-data="{
             state: $wire.entangle('{{ $statePath }}').defer,
-            widgetId: null
+            widgetId: null,
         }"
-         x-load-js="['https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit&onload=onTurnstileLoad']"
          x-init="(() => {
             let options = {
                 sitekey: '{{config('turnstile.turnstile_site_key')}}',
@@ -63,12 +63,6 @@
             }
         })()"
     >
-        <div data-sitekey="{{config('turnstile.turnstile_site_key')}}"
-             data-theme="{{ $theme }}"
-             data-language="{{ $language }}"
-             data-size="{{ $size }}"
-             x-ref="turnstile"
-        >
-        </div>
+        <div x-ref="turnstile"></div>
     </div>
 </x-dynamic-component>


### PR DESCRIPTION
Fixes #33 

  Fix Turnstile widget for Livewire dynamic content and collapsing panels

### Problem

  The current implementation causes issues when used in Livewire components with dynamic content (collapsing panels, SPAs):

  1. Widget disappears after completion
  2. Multiple render attempts - IntersectionObserver + onload callback can both fire, causing Cloudflare to flag as suspicious behavior
  3. No cleanup on component destruction - Causes memory leaks and duplicate widgets when Livewire re-renders
  4. Not following Cloudflare's SPA recommendations - Official docs recommend explicit rendering with cleanup for dynamic content

### Fix:

  | Change                   | Cloudflare Docs        | Necessary for Livewire? |
  |--------------------------|------------------------|-------------------------|
  | render=explicit          | ✅ Recommended for SPAs | ✅ YES                   |
  | onload callback          | ✅ Official pattern     | ✅ YES                   |
  | turnstile.remove()       | ✅ Required for SPAs    | ✅ CRITICAL              |
  | Using widgetId           | ✅ All examples use it  | ✅ YES                   |
  | Multiple render guard    | ❌ Not shown            | ⚠️ Defensive            |
  | API already loaded check | ✅ Shown in examples    | ✅ For re-renders        |