### PR TITLE
Update filament/filament requirement to support version 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
-        "filament/filament": "^3.0",
+        "filament/filament": "^3.0|^4.0",
         "laravel/pint": "^1.0",
         "larastan/larastan": "^2.8|^3.0",
         "nunomaduro/collision": "^7.0|^8.0",


### PR DESCRIPTION
This pull request makes a minor update to the development dependencies in the `composer.json` file, expanding the supported versions of the `filament/filament` package.

- Updated the `filament/filament` development dependency version constraint from `^3.0` to `^3.0|^4.0` in `composer.json`, allowing compatibility with both version 3 and 4.